### PR TITLE
Add files via upload

### DIFF
--- a/src/afuse.c
+++ b/src/afuse.c
@@ -1892,8 +1892,6 @@ int main(int argc, char *argv[])
         strcpy(temp_dir_name, user_options.mount_dir);
         strcpy(temp_dir_name+strlen(user_options.mount_dir), TMP_DIR_TEMPLATE2);
     }
-    fprintf(stderr, "dir: %s\n", temp_dir_name); 
-    return 1;
 
 	// Check for required parameters
 	if (!user_options.mount_command_template


### PR DESCRIPTION
This patch adds the -o mount_dir=DIR option, which allows users to specify a directory under which all temporary mounts are made.