### PR TITLE
Add example usage of afuse with NFS to README

### DIFF
--- a/README
+++ b/README
@@ -54,6 +54,12 @@ For this example to work, the sshfs invocation must not require user
 interactivity (i.e.  asking for a password). So you probably want to be
 using something like ssh-agent.
 
+You can use afuse with NFS with the following command:
+	
+	afuse -o mount_template="mount -t nfs %r %m" \
+      	-o unmount_template="umount %m" \
+      	~/afuse_mount/
+
 Alternatively, if want interactivity, add -f to the afuse invocation.
 
 


### PR DESCRIPTION
This commit adds a concrete usage example of afuse with an NFS mount command to the README file. 

Many new users may not immediately understand how to use the `mount_template` and `unmount_template` options in practical scenarios. By including a real-world example, this improves the onboarding experience and makes the documentation more actionable and accessible.

This change does not affect the core functionality or codebase and is strictly a documentation improvement aimed at clarity and usability.